### PR TITLE
Harden REPL scripts for missing-Python / no-elevation hosts

### DIFF
--- a/create_REPL.ps1
+++ b/create_REPL.ps1
@@ -39,6 +39,7 @@ function Ensure-Admin {
   $current = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
   if (-not $current.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Warn "Elevation required for installation. Relaunching as Administrator..."
+    Write-Warn "Python will install in the new elevated window, and the REPL will open there. This window will close."
     $psi = @{
       FilePath  = "powershell.exe"
       ArgumentList = "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`""

--- a/create_REPL.sh
+++ b/create_REPL.sh
@@ -53,22 +53,32 @@ install_python_macos() {
 }
 
 install_python_linux() {
+  SUDO=""
+  if [ "$(id -u)" -ne 0 ]; then
+    if require_cmd sudo; then
+      SUDO="sudo"
+    else
+      err "Installing packages requires root. You are not root and 'sudo' is not available. Install Python 3 manually and re-run."
+      exit 1
+    fi
+  fi
+
   if require_cmd apt-get; then
     log "Installing Python via apt-get..."
-    sudo apt-get update -y
-    sudo apt-get install -y python3 python3-pip python3-venv
+    $SUDO apt-get update -y
+    $SUDO apt-get install -y python3 python3-pip python3-venv
   elif require_cmd dnf; then
     log "Installing Python via dnf..."
-    sudo dnf install -y python3 python3-pip
+    $SUDO dnf install -y python3 python3-pip
   elif require_cmd yum; then
     log "Installing Python via yum..."
-    sudo yum install -y python3 python3-pip
+    $SUDO yum install -y python3 python3-pip
   elif require_cmd pacman; then
     log "Installing Python via pacman..."
-    sudo pacman -Sy --noconfirm python
+    $SUDO pacman -Sy --noconfirm python
   elif require_cmd zypper; then
     log "Installing Python via zypper..."
-    sudo zypper --non-interactive install python3
+    $SUDO zypper --non-interactive install python3
   else
     err "No supported package manager found (apt/dnf/yum/pacman/zypper). Install Python 3 manually and re-run."
     exit 1

--- a/create_REPL.sh
+++ b/create_REPL.sh
@@ -35,6 +35,16 @@ pick_python() {
   return 1
 }
 
+# A uv-managed Python isn't necessarily linked onto PATH as python3/python.
+pick_uv_python() {
+  require_cmd uv || return 1
+  local candidate
+  candidate=$(uv python find 2>/dev/null) || return 1
+  [ -x "$candidate" ] || return 1
+  PY="$candidate"
+  return 0
+}
+
 install_python_macos() {
   if ! require_cmd brew; then
     err "Homebrew is not installed. Install it from https://brew.sh/ and re-run."
@@ -52,14 +62,38 @@ install_python_macos() {
   }
 }
 
+install_python_via_uv() {
+  if ! require_cmd uv; then
+    if require_cmd curl; then
+      log "Installing uv (user-local, no root needed) via curl..."
+      curl -LsSf https://astral.sh/uv/install.sh | sh
+    elif require_cmd wget; then
+      log "Installing uv (user-local, no root needed) via wget..."
+      wget -qO- https://astral.sh/uv/install.sh | sh
+    else
+      err "No root access, and neither curl nor wget is available to bootstrap uv. Install Python 3 manually and re-run."
+      exit 1
+    fi
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+    if ! require_cmd uv; then
+      err "uv installation did not produce a usable 'uv' on PATH. Install Python 3 manually and re-run."
+      exit 1
+    fi
+  fi
+
+  log "Installing a user-local Python via uv..."
+  uv python install 3.12
+}
+
 install_python_linux() {
   SUDO=""
   if [ "$(id -u)" -ne 0 ]; then
     if require_cmd sudo; then
       SUDO="sudo"
     else
-      err "Installing packages requires root. You are not root and 'sudo' is not available. Install Python 3 manually and re-run."
-      exit 1
+      warn "Not root and 'sudo' is not available; cannot use a system package manager."
+      install_python_via_uv
+      return 0
     fi
   fi
 
@@ -80,13 +114,13 @@ install_python_linux() {
     log "Installing Python via zypper..."
     $SUDO zypper --non-interactive install python3
   else
-    err "No supported package manager found (apt/dnf/yum/pacman/zypper). Install Python 3 manually and re-run."
-    exit 1
+    warn "No supported package manager found (apt/dnf/yum/pacman/zypper)."
+    install_python_via_uv
   fi
 }
 
 ensure_python() {
-  if pick_python; then
+  if pick_python || pick_uv_python; then
     log "Found Python: $PY ($($PY -V 2>&1))"
     return 0
   fi
@@ -98,7 +132,7 @@ ensure_python() {
     install_python_linux
   fi
 
-  if ! pick_python; then
+  if ! pick_python && ! pick_uv_python; then
     err "Python 3 installation appears to have failed. Please install manually and re-run."
     exit 1
   fi


### PR DESCRIPTION
Addresses #2 — tested both `create_REPL.sh` and `create_REPL.ps1` and fixed what I found.

## `create_REPL.sh` (tested live on Linux in this environment)

- **Bug**: `install_python_linux` always ran package-manager installs with a hardcoded elevation prefix, even when already root (elevation tool not installed) or when not root and no elevation tool exists (common on minimal root-based containers/CI images — exactly the "fresh Linux, no Python" scenario this issue asks about). That failed with a confusing "command not found" instead of installing anything.
- **Fix**: only prefix the elevation command when actually needed (non-root) and available. When not root and no elevation tool is present, fall back to installing a user-local Python via `uv` (no root required) — bootstrapping `uv` itself via `curl`/`wget` if it isn't already present, then `uv python install`. `pick_uv_python` resolves the interpreter afterward since a uv-managed Python doesn't land on `PATH` as `python3`.
- **Verified end-to-end** in this sandbox by stripping `python3`/`python`/elevation tools from `PATH` and confirming: correct fallback message → real `uv python install 3.12` download → interpreter found → REPL launches with `clear()` working. Also re-verified the golden path (Python already present) is unaffected.
- Could not test the `curl`/`wget` → `uv` bootstrap sub-step live (this sandbox's network allowlist doesn't include the installer host), but it's the standard documented uv install command.

## `create_REPL.ps1` (static review only — no Windows/pwsh available to execute)

- Noted a UX gap: when elevation is needed, the script relaunches itself as Administrator and the original window exits immediately, so the Python install *and* the resulting REPL end up running in the new elevated window rather than the user's original one. Didn't attempt a full rewrite of the elevation flow since I can't test it on this platform — added a `Write-Warn` before the relaunch so the user isn't confused when their original window just closes.

## Testing

- `bash -n create_REPL.sh` — syntax OK
- Live-tested golden path and the full no-root/no-elevation-tool/no-Python fallback chain (see above)
- `make lint` — clean