### PR TITLE
Add Extra Practice sections to weeks 7-15

### DIFF
--- a/src/week07/week7_code.ipynb
+++ b/src/week07/week7_code.ipynb
@@ -353,6 +353,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d2a4b549",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bb4f3a0",
+   "source": "1) Even checker\n    - Story: write a function that reports whether a whole number is even.\n    - Signature: `def is_even(n: int) -> bool`\n\n2) Temperature status (as a function)\n    - Story: reuse the freezing/cold/comfortable/boiling bands from Week 4, but as a reusable function instead of one-off code.\n    - Signature: `def temp_status(temp_f: int) -> str` — returns `\"freezing\"`, `\"cold\"`, `\"comfortable\"`, or `\"boiling\"`\n\n3) Safe divide\n    - Story: division by zero shouldn't crash your program. Catch it and signal failure with `None` instead.\n    - Signature: `def safe_divide(a: float, b: float) -> float | None`\n\n4) Largest of three\n    - Story: find the largest of three numbers *without* using the built-in `max()`.\n    - Signature: `def max_of_three(a: float, b: float, c: float) -> float`\n\n5) CHALLENGE: FizzBuzz for one number\n    - Story: classic FizzBuzz, but just for a single number `n`. Return `\"Fizz\"` if divisible by 3, `\"Buzz\"` if divisible by 5, `\"FizzBuzz\"` if divisible by both, otherwise the number itself as a string.\n    - Signature: `def fizzbuzz_one(n: int) -> str`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7162bcb8",
+   "source": "def is_even(n: int) -> bool: ...\n\n\ndef temp_status(temp_f: int) -> str: ...\n\n\ndef safe_divide(a: float, b: float) -> float | None: ...\n\n\ndef max_of_three(a: float, b: float, c: float) -> float: ...\n\n\ndef fizzbuzz_one(n: int) -> str: ...\n\n\nprint(is_even(4))\nprint(temp_status(70))\nprint(safe_divide(10, 2))\nprint(max_of_three(3, 9, 5))\nprint(fizzbuzz_one(15))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5b1b0c6",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "2c1c0ee8",
+   "source": "def is_even(n: int) -> bool:\n    return n % 2 == 0\n\n\ndef temp_status(temp_f: int) -> str:\n    if 0 <= temp_f <= 32:\n        return 'freezing'\n    elif temp_f < 0:\n        return 'cold'\n    elif temp_f < 212:\n        return 'comfortable'\n    else:\n        return 'boiling'\n\n\ndef safe_divide(a: float, b: float) -> float | None:\n    try:\n        return a / b\n    except ZeroDivisionError:\n        return None\n\n\ndef max_of_three(a: float, b: float, c: float) -> float:\n    largest = a\n    if b > largest:\n        largest = b\n    if c > largest:\n        largest = c\n    return largest\n\n\ndef fizzbuzz_one(n: int) -> str:\n    if n % 3 == 0 and n % 5 == 0:\n        return 'FizzBuzz'\n    elif n % 3 == 0:\n        return 'Fizz'\n    elif n % 5 == 0:\n        return 'Buzz'\n    else:\n        return str(n)\n\n\nprint(is_even(4), is_even(7))\nprint(temp_status(-5), temp_status(20), temp_status(70), temp_status(300))\nprint(safe_divide(10, 2), safe_divide(10, 0))\nprint(max_of_three(3, 9, 5))\nprint(fizzbuzz_one(15), fizzbuzz_one(9), fizzbuzz_one(10), fizzbuzz_one(7))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [

--- a/src/week09/week9_code.ipynb
+++ b/src/week09/week9_code.ipynb
@@ -231,6 +231,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e57f0a0f",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99bf7c9b",
+   "source": "1) Countdown\n    - Story: print every whole number from `n` down to `0`.\n    - Signature: `def countdown(n: int) -> None`\n\n2) Number guessing (with attempt counter)\n    - Story: given a `target` number and a list of `guesses` (simulating a player's guesses in order), return how many guesses it took to hit the target.\n    - Signature: `def guess_number(target: int, guesses: list) -> int`\n\n3) Average until 'done'\n    - Story: given a list of number-strings ending in the sentinel `\"done\"`, average all the numbers that came before it.\n    - Signature: `def average_until_done(entries: list) -> float`\n\n4) Sum of digits\n    - Story: add up the individual digits of a whole number (e.g. `123` -> `1 + 2 + 3 = 6`) using a `while` loop, no string conversion.\n    - Signature: `def sum_of_digits(n: int) -> int`\n\n5) CHALLENGE: limited password attempts\n    - Story: given a `target` password and a list of `attempts_list` (simulating what a user typed, in order), return whether they got it right within `max_attempts` tries (default 3).\n    - Signature: `def check_password(target: str, attempts_list: list, max_attempts: int = 3) -> bool`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "276105df",
+   "source": "def countdown(n: int) -> None: ...\n\n\ndef guess_number(target: int, guesses: list) -> int: ...\n\n\ndef average_until_done(entries: list) -> float: ...\n\n\ndef sum_of_digits(n: int) -> int: ...\n\n\ndef check_password(target: str, attempts_list: list, max_attempts: int = 3) -> bool: ...\n\n\ncountdown(3)\nprint(guess_number(7, [3, 5, 7]))\nprint(average_until_done(['80', '90', '100', 'done']))\nprint(sum_of_digits(12345))\nprint(check_password('hunter2', ['wrong', 'hunter2']))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa615ede",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ddfaa1c2",
+   "source": "def countdown(n: int) -> None:\n    while n >= 0:\n        print(n)\n        n -= 1\n\n\ndef guess_number(target: int, guesses: list) -> int:\n    attempts = 0\n    gi = iter(guesses)\n    while True:\n        guess = next(gi)\n        attempts += 1\n        if guess == target:\n            return attempts\n\n\ndef average_until_done(entries: list) -> float:\n    total = 0.0\n    count = 0\n    ei = iter(entries)\n    while True:\n        entry = next(ei)\n        if entry == 'done':\n            break\n        total += float(entry)\n        count += 1\n    return total / count if count else 0.0\n\n\ndef sum_of_digits(n: int) -> int:\n    n = abs(n)\n    total = 0\n    while n > 0:\n        total += n % 10\n        n //= 10\n    return total\n\n\ndef check_password(target: str, attempts_list: list, max_attempts: int = 3) -> bool:\n    attempts = 0\n    ai = iter(attempts_list)\n    while attempts < max_attempts:\n        attempt = next(ai)\n        attempts += 1\n        if attempt == target:\n            return True\n    return False\n\n\ncountdown(3)\nprint(guess_number(7, [3, 5, 7]))\nprint(average_until_done(['80', '90', '100', 'done']))\nprint(sum_of_digits(12345))\nprint(check_password('hunter2', ['wrong', 'hunter2']), check_password('hunter2', ['a', 'b', 'c']))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [

--- a/src/week10/week10_code.ipynb
+++ b/src/week10/week10_code.ipynb
@@ -212,6 +212,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9fd343e5",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b07f66d5",
+   "source": "1) Count vowels\n    - Story: count how many vowels (a, e, i, o, u) appear in a sentence, case-insensitive.\n    - Signature: `def count_vowels(s: str) -> int`\n\n2) Palindrome checker\n    - Story: check whether a string reads the same forwards and backwards, ignoring spaces and case. Use slicing, not a loop.\n    - Signature: `def is_palindrome(s: str) -> bool`\n\n3) Caesar shift by one\n    - Story: shift every letter forward by one in the alphabet (wrapping `z` -> `a`), leaving non-letters untouched.\n    - Signature: `def caesar_shift_one(s: str) -> str`\n\n4) Count words\n    - Story: count how many words are in a sentence.\n    - Signature: `def count_words(s: str) -> int`\n\n5) CHALLENGE: reverse each word, keep order\n    - Story: reverse the letters *within* each word but keep the words in their original order (e.g. `\"hello world\"` -> `\"olleh dlrow\"`).\n    - Signature: `def reverse_each_word(s: str) -> str`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "817d74f7",
+   "source": "def count_vowels(s: str) -> int: ...\n\n\ndef is_palindrome(s: str) -> bool: ...\n\n\ndef caesar_shift_one(s: str) -> str: ...\n\n\ndef count_words(s: str) -> int: ...\n\n\ndef reverse_each_word(s: str) -> str: ...\n\n\nprint(count_vowels('Hello World'))\nprint(is_palindrome('racecar'))\nprint(caesar_shift_one('abc XYZ!'))\nprint(count_words('the quick brown fox'))\nprint(reverse_each_word('hello world'))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "508821f6",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7700b916",
+   "source": "def count_vowels(s: str) -> int:\n    count = 0\n    for ch in s.lower():\n        if ch in 'aeiou':\n            count += 1\n    return count\n\n\ndef is_palindrome(s: str) -> bool:\n    cleaned = s.lower().replace(' ', '')\n    return cleaned == cleaned[::-1]\n\n\ndef caesar_shift_one(s: str) -> str:\n    shifted = ''\n    for ch in s:\n        if ch.isalpha():\n            base = ord('A') if ch.isupper() else ord('a')\n            shifted += chr((ord(ch) - base + 1) % 26 + base)\n        else:\n            shifted += ch\n    return shifted\n\n\ndef count_words(s: str) -> int:\n    return len(s.split())\n\n\ndef reverse_each_word(s: str) -> str:\n    return ' '.join(word[::-1] for word in s.split())\n\n\nprint(count_vowels('Hello World'))\nprint(is_palindrome('racecar'), is_palindrome('hello'))\nprint(caesar_shift_one('abc XYZ!'))\nprint(count_words('the quick brown fox'))\nprint(reverse_each_word('hello world'))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [

--- a/src/week11/week11_code.ipynb
+++ b/src/week11/week11_code.ipynb
@@ -926,6 +926,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2024a9b2",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98996f41",
+   "source": "1) High/low without max()/min()\n    - Story: find the highest and lowest values in a list without using the built-in `max()`/`min()`.\n    - Signature: `def find_high_low(nums: list) -> tuple`\n\n2) Dedupe, preserving order\n    - Story: remove duplicates from a list *without* losing the original order (the `list(set(...))` trick from class doesn't preserve order).\n    - Signature: `def dedupe_preserve_order(items: list) -> list`\n\n3) Split evens and odds\n    - Story: split a list of numbers into two lists — evens and odds — in one pass.\n    - Signature: `def split_evens_odds(nums: list) -> tuple`\n\n4) Sum without sum()\n    - Story: total up a list of numbers without using the built-in `sum()`.\n    - Signature: `def list_sum(nums: list) -> float`\n\n5) CHALLENGE: second largest\n    - Story: find the *second* largest distinct-position value in a list, in a single pass (no sorting).\n    - Signature: `def second_largest(nums: list) -> float`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b6a34bc7",
+   "source": "def find_high_low(nums: list) -> tuple: ...\n\n\ndef dedupe_preserve_order(items: list) -> list: ...\n\n\ndef split_evens_odds(nums: list) -> tuple: ...\n\n\ndef list_sum(nums: list) -> float: ...\n\n\ndef second_largest(nums: list) -> float: ...\n\n\nprint(find_high_low([3, 7, 1, 9, 4]))\nprint(dedupe_preserve_order([1, 2, 2, 3, 1, 4]))\nprint(split_evens_odds([1, 2, 3, 4, 5, 6]))\nprint(list_sum([1, 2, 3, 4]))\nprint(second_largest([5, 1, 9, 9, 3]))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a54c30b1",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "27e08aff",
+   "source": "def find_high_low(nums: list) -> tuple:\n    highest = nums[0]\n    lowest = nums[0]\n    for n in nums:\n        if n > highest:\n            highest = n\n        if n < lowest:\n            lowest = n\n    return highest, lowest\n\n\ndef dedupe_preserve_order(items: list) -> list:\n    seen = set()\n    result = []\n    for item in items:\n        if item not in seen:\n            result.append(item)\n            seen.add(item)\n    return result\n\n\ndef split_evens_odds(nums: list) -> tuple:\n    evens = []\n    odds = []\n    for n in nums:\n        if n % 2 == 0:\n            evens.append(n)\n        else:\n            odds.append(n)\n    return evens, odds\n\n\ndef list_sum(nums: list) -> float:\n    total = 0\n    for n in nums:\n        total += n\n    return total\n\n\ndef second_largest(nums: list) -> float:\n    largest = second = float('-inf')\n    for n in nums:\n        if n > largest:\n            second = largest\n            largest = n\n        elif largest > n > second:\n            second = n\n    return second\n\n\nprint(find_high_low([3, 7, 1, 9, 4]))\nprint(dedupe_preserve_order([1, 2, 2, 3, 1, 4]))\nprint(split_evens_odds([1, 2, 3, 4, 5, 6]))\nprint(list_sum([1, 2, 3, 4]))\nprint(second_largest([5, 1, 9, 9, 3]))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [

--- a/src/week12/week12_code.ipynb
+++ b/src/week12/week12_code.ipynb
@@ -941,6 +941,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a63ed2fb",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a2237f2",
+   "source": "1) Per-student averages\n    - Story: given a nested list where each inner list is one student's quiz scores, return a list of each student's average.\n    - Signature: `def student_averages(quiz_scores: list) -> list`\n\n2) Flatten a nested list\n    - Story: flatten a list that may be nested arbitrarily deep into one flat list.\n    - Signature: `def flatten(nested: list) -> list`\n\n3) Rotate a list\n    - Story: rotate a list to the right by `k` positions (e.g. `[1,2,3,4,5]` rotated by `2` -> `[4,5,1,2,3]`).\n    - Signature: `def rotate_list(items: list, k: int) -> list`\n\n4) Merge two sorted lists\n    - Story: merge two already-sorted lists into one sorted list, without using `sort()`/`sorted()`.\n    - Signature: `def merge_sorted(a: list, b: list) -> list`\n\n5) CHALLENGE: row and column sums\n    - Story: given a rectangular grid (list of lists), return the sum of each row and the sum of each column.\n    - Signature: `def row_col_sums(grid: list) -> tuple`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "9bfbeb2d",
+   "source": "def student_averages(quiz_scores: list) -> list: ...\n\n\ndef flatten(nested: list) -> list: ...\n\n\ndef rotate_list(items: list, k: int) -> list: ...\n\n\ndef merge_sorted(a: list, b: list) -> list: ...\n\n\ndef row_col_sums(grid: list) -> tuple: ...\n\n\nprint(student_averages([[80, 90, 100], [70, 75, 80]]))\nprint(flatten([1, [2, 3, [4, 5]], 6]))\nprint(rotate_list([1, 2, 3, 4, 5], 2))\nprint(merge_sorted([1, 3, 5], [2, 4, 6]))\nprint(row_col_sums([[1, 2, 3], [4, 5, 6]]))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "835ee2d4",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "8f26ac70",
+   "source": "def student_averages(quiz_scores: list) -> list:\n    return [sum(row) / len(row) for row in quiz_scores]\n\n\ndef flatten(nested: list) -> list:\n    flat = []\n    for item in nested:\n        if isinstance(item, list):\n            flat.extend(flatten(item))\n        else:\n            flat.append(item)\n    return flat\n\n\ndef rotate_list(items: list, k: int) -> list:\n    if not items:\n        return items\n    k = k % len(items)\n    return items[-k:] + items[:-k] if k else items[:]\n\n\ndef merge_sorted(a: list, b: list) -> list:\n    merged = []\n    i = j = 0\n    while i < len(a) and j < len(b):\n        if a[i] <= b[j]:\n            merged.append(a[i])\n            i += 1\n        else:\n            merged.append(b[j])\n            j += 1\n    merged.extend(a[i:])\n    merged.extend(b[j:])\n    return merged\n\n\ndef row_col_sums(grid: list) -> tuple:\n    row_sums = [sum(row) for row in grid]\n    col_sums = [sum(row[i] for row in grid) for i in range(len(grid[0]))]\n    return row_sums, col_sums\n\n\nprint(student_averages([[80, 90, 100], [70, 75, 80]]))\nprint(flatten([1, [2, 3, [4, 5]], 6]))\nprint(rotate_list([1, 2, 3, 4, 5], 2))\nprint(merge_sorted([1, 3, 5], [2, 4, 6]))\nprint(row_col_sums([[1, 2, 3], [4, 5, 6]]))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [

--- a/src/week13/week13_code.ipynb
+++ b/src/week13/week13_code.ipynb
@@ -527,6 +527,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f451d2ca",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08ebd74b",
+   "source": "1) Extract vowels (comprehension)\n    - Story: build a list of every vowel in a string, using a list comprehension.\n    - Signature: `def extract_vowels(s: str) -> list`\n\n2) City averages (comprehension)\n    - Story: reuse the weekly-temps grid from earlier — compute each city's average temperature with a single-line comprehension.\n    - Signature: `def city_averages(weekly_temps: list) -> list`\n\n3) Add two grids elementwise\n    - Story: given two same-size grids, return a new grid where each cell is the sum of the corresponding cells.\n    - Signature: `def add_grids(grid_a: list, grid_b: list) -> list`\n\n4) Even squares\n    - Story: build a list of squares of the even numbers from 1 to `n`, using a comprehension with a filter.\n    - Signature: `def even_squares(n: int) -> list`\n\n5) CHALLENGE: flatten (comprehension version)\n    - Story: same idea as week12's `flatten`, but for a grid that's exactly one level deep, done as a single nested comprehension.\n    - Signature: `def flatten_comprehension(nested: list) -> list`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "9dd6a388",
+   "source": "def extract_vowels(s: str) -> list: ...\n\n\ndef city_averages(weekly_temps: list) -> list: ...\n\n\ndef add_grids(grid_a: list, grid_b: list) -> list: ...\n\n\ndef even_squares(n: int) -> list: ...\n\n\ndef flatten_comprehension(nested: list) -> list: ...\n\n\nprint(extract_vowels('Hello World'))\nprint(city_averages([[78, 81, 79], [69, 72, 88]]))\nprint(add_grids([[1, 2], [3, 4]], [[5, 6], [7, 8]]))\nprint(even_squares(10))\nprint(flatten_comprehension([[1, 2], [3, 4], [5]]))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "668769ba",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1a4a43d5",
+   "source": "def extract_vowels(s: str) -> list:\n    return [ch for ch in s.lower() if ch in 'aeiou']\n\n\ndef city_averages(weekly_temps: list) -> list:\n    return [sum(city) / len(city) for city in weekly_temps]\n\n\ndef add_grids(grid_a: list, grid_b: list) -> list:\n    return [[grid_a[r][c] + grid_b[r][c] for c in range(len(grid_a[0]))] for r in range(len(grid_a))]\n\n\ndef even_squares(n: int) -> list:\n    return [x**2 for x in range(1, n + 1) if x % 2 == 0]\n\n\ndef flatten_comprehension(nested: list) -> list:\n    return [item for row in nested for item in row]\n\n\nprint(extract_vowels('Hello World'))\nprint(city_averages([[78, 81, 79], [69, 72, 88]]))\nprint(add_grids([[1, 2], [3, 4]], [[5, 6], [7, 8]]))\nprint(even_squares(10))\nprint(flatten_comprehension([[1, 2], [3, 4], [5]]))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [

--- a/src/week14/week14_code.ipynb
+++ b/src/week14/week14_code.ipynb
@@ -439,6 +439,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "adddd4e9",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00b605cc",
+   "source": "1) Shopping cart item counts\n    - Story: given a list of purchased item names (with repeats), count how many of each were bought.\n    - Signature: `def item_counts(purchases: list) -> dict`\n\n2) Merge two score dicts\n    - Story: merge two dicts of scores, summing the values for any key present in both.\n    - Signature: `def merge_scores(a: dict, b: dict) -> dict`\n\n3) Student grades -> averages\n    - Story: given a dict mapping student name to a list of their grades, return a new dict mapping each student to their average.\n    - Signature: `def student_avg_dict(grades: dict) -> dict`\n\n4) Invert a dictionary\n    - Story: swap a dict's keys and values.\n    - Signature: `def invert_dict(d: dict) -> dict`\n\n5) CHALLENGE: top student\n    - Story: given a dict of student name -> grade, return the name of the student with the highest grade.\n    - Signature: `def top_student(grades: dict) -> str`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "36e264b9",
+   "source": "def item_counts(purchases: list) -> dict: ...\n\n\ndef merge_scores(a: dict, b: dict) -> dict: ...\n\n\ndef student_avg_dict(grades: dict) -> dict: ...\n\n\ndef invert_dict(d: dict) -> dict: ...\n\n\ndef top_student(grades: dict) -> str: ...\n\n\nprint(item_counts(['apple', 'banana', 'apple', 'apple', 'banana']))\nprint(merge_scores({'a': 5, 'b': 3}, {'b': 2, 'c': 4}))\nprint(student_avg_dict({'Alice': [90, 95], 'Bob': [70, 80]}))\nprint(invert_dict({'a': 1, 'b': 2}))\nprint(top_student({'Alice': 90, 'Bob': 95, 'Cleo': 88}))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4394f305",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "07b6f105",
+   "source": "def item_counts(purchases: list) -> dict:\n    counts = {}\n    for item in purchases:\n        counts[item] = counts.get(item, 0) + 1\n    return counts\n\n\ndef merge_scores(a: dict, b: dict) -> dict:\n    merged = dict(a)\n    for key, value in b.items():\n        merged[key] = merged.get(key, 0) + value\n    return merged\n\n\ndef student_avg_dict(grades: dict) -> dict:\n    return {name: sum(scores) / len(scores) for name, scores in grades.items()}\n\n\ndef invert_dict(d: dict) -> dict:\n    return {v: k for k, v in d.items()}\n\n\ndef top_student(grades: dict) -> str:\n    return max(grades, key=grades.get)\n\n\nprint(item_counts(['apple', 'banana', 'apple', 'apple', 'banana']))\nprint(merge_scores({'a': 5, 'b': 3}, {'b': 2, 'c': 4}))\nprint(student_avg_dict({'Alice': [90, 95], 'Bob': [70, 80]}))\nprint(invert_dict({'a': 1, 'b': 2}))\nprint(top_student({'Alice': 90, 'Bob': 95, 'Cleo': 88}))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [

--- a/src/week15/week15_code.ipynb
+++ b/src/week15/week15_code.ipynb
@@ -558,6 +558,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bbe35507",
+   "source": "## Extra Practice",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2461c19a",
+   "source": "1) Book\n    - Story: a simple dataclass for a book, with a method that says whether it's a \"long\" book (over 400 pages).\n    - Signature: `Book(title: str, author: str, pages: int)` with `is_long() -> bool`\n\n2) Inventory\n    - Story: an `Inventory` that holds a list of `Item`s (name, price, quantity), with methods to add an item and compute total value.\n    - Signature: `Item(name: str, price: float, quantity: int = 1)`, `Inventory(items: list[Item] = ...)` with `add_item(item)` and `total_value() -> float`\n\n3) BankAccount\n    - Story: a `BankAccount` that validates on creation (balance can't start negative) and supports withdrawals that refuse to overdraw.\n    - Signature: `BankAccount(owner: str, balance: float = 0.0)` with `withdraw(withdrawal: float) -> None` (raises `ValueError` if insufficient funds)\n\n4) Rectangle\n    - Story: a `Rectangle` with methods for area and perimeter.\n    - Signature: `Rectangle(width: float, height: float)` with `area() -> float` and `perimeter() -> float`\n\n5) CHALLENGE: Temperature\n    - Story: a `Temperature` dataclass storing Celsius, validating it's not below absolute zero (-273.15), with a method to convert to Fahrenheit.\n    - Signature: `Temperature(celsius: float)` with `to_fahrenheit() -> float`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "eb9ac3de",
+   "source": "from dataclasses import dataclass, field\n\n\n@dataclass\nclass Book:\n    title: str\n    author: str\n    pages: int\n\n    def is_long(self) -> bool: ...\n\n\n@dataclass\nclass Item:\n    name: str\n    price: float\n    quantity: int = 1\n\n\n@dataclass\nclass Inventory:\n    items: list = field(default_factory=list)\n\n    def add_item(self, item: Item) -> None: ...\n\n    def total_value(self) -> float: ...\n\n\n@dataclass\nclass BankAccount:\n    owner: str\n    balance: float = 0.0\n\n    def __post_init__(self): ...\n\n    def withdraw(self, withdrawal: float) -> None: ...\n\n\n@dataclass\nclass Rectangle:\n    width: float\n    height: float\n\n    def area(self) -> float: ...\n\n    def perimeter(self) -> float: ...\n\n\n@dataclass\nclass Temperature:\n    celsius: float\n\n    def __post_init__(self): ...\n\n    def to_fahrenheit(self) -> float: ...\n\n\nbook = Book('War and Peace', 'Tolstoy', 1225)\nprint(book.is_long())\n\ninventory = Inventory()\ninventory.add_item(Item('Widget', 2.5, 4))\nprint(inventory.total_value())\n\naccount = BankAccount('Alice', 100)\naccount.withdraw(40)\nprint(account.balance)\n\nrect = Rectangle(4, 5)\nprint(rect.area(), rect.perimeter())\n\ntemp = Temperature(20)\nprint(temp.to_fahrenheit())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c4ff22a",
+   "source": "### My Solutions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "5a18def0",
+   "source": "from dataclasses import dataclass, field\n\n\n@dataclass\nclass Book:\n    title: str\n    author: str\n    pages: int\n\n    def is_long(self) -> bool:\n        return self.pages > 400\n\n\n@dataclass\nclass Item:\n    name: str\n    price: float\n    quantity: int = 1\n\n\n@dataclass\nclass Inventory:\n    items: list = field(default_factory=list)\n\n    def add_item(self, item: Item) -> None:\n        self.items.append(item)\n\n    def total_value(self) -> float:\n        return sum(item.price * item.quantity for item in self.items)\n\n\n@dataclass\nclass BankAccount:\n    owner: str\n    balance: float = 0.0\n\n    def __post_init__(self):\n        if self.balance < 0:\n            raise ValueError('balance must be >= 0')\n\n    def withdraw(self, withdrawal: float) -> None:\n        if withdrawal > self.balance:\n            raise ValueError('insufficient funds')\n        self.balance -= withdrawal\n\n\n@dataclass\nclass Rectangle:\n    width: float\n    height: float\n\n    def area(self) -> float:\n        return self.width * self.height\n\n    def perimeter(self) -> float:\n        return 2 * (self.width + self.height)\n\n\n@dataclass\nclass Temperature:\n    celsius: float\n\n    def __post_init__(self):\n        if self.celsius < -273.15:\n            raise ValueError('temperature below absolute zero')\n\n    def to_fahrenheit(self) -> float:\n        return self.celsius * 9 / 5 + 32\n\n\nbook = Book('War and Peace', 'Tolstoy', 1225)\nprint(book.is_long())\n\ninventory = Inventory()\ninventory.add_item(Item('Widget', 2.5, 4))\ninventory.add_item(Item('Gadget', 10.0, 1))\nprint(inventory.total_value())\n\naccount = BankAccount('Alice', 100)\naccount.withdraw(40)\nprint(account.balance)\ntry:\n    account.withdraw(1000)\nexcept ValueError as e:\n    print('Expected error:', e)\n\nrect = Rectangle(4, 5)\nprint(rect.area(), rect.perimeter())\n\ntemp = Temperature(20)\nprint(temp.to_fahrenheit())\ntry:\n    Temperature(-300)\nexcept ValueError as e:\n    print('Expected error:', e)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b21d706b",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Closes #64. Adds a new "## Extra Practice" section at the end of each of weeks 7, 9, 10, 11, 12, 13, 14, 15 (skipping week08 — no class), before the "Created by..." footer cell. 5 problems per week, escalating difficulty, following the existing story/scenario + stub + "My Solutions" pattern already used elsewhere in these notebooks (e.g. the "In class questions" cells in weeks 11/12/13).

- **week07 (Functions)**: is_even, temp_status, safe_divide, max_of_three, FizzBuzz-for-one
- **week09 (While Loops)**: countdown, number-guessing with attempt count, average-until-'done', sum of digits, limited password attempts
- **week10 (Strings)**: count vowels, palindrome check via slicing, Caesar shift by one, count words, reverse each word keeping order
- **week11 (Lists)**: high/low without max()/min(), dedupe preserving order, split evens/odds, sum without sum(), second largest
- **week12 (Lists cont.)**: per-student averages from nested scores, flatten arbitrarily-nested list, rotate by k, merge two sorted lists, row/column sums
- **week13 (Lists cont. / comprehensions)**: comprehension versions — extract vowels, city averages, elementwise grid addition, even squares, flatten
- **week14 (Dictionaries)**: shopping-cart counts, merge two score dicts, student grades → averages, invert a dict, top student by grade
- **week15 (Dataclasses)**: Book, Inventory (holding Item dataclasses), BankAccount with validation, Rectangle, Temperature with absolute-zero validation

## Testing
- Wrote and executed every one of the 40 solutions in a standalone script first, before touching any notebook — all produce correct output (verified against hand-computed expected values, e.g. `Temperature(20).to_fahrenheit() == 68.0`, `rotate_list([1,2,3,4,5], 2) == [4,5,1,2,3]`, `BankAccount.withdraw` and `Temperature.__post_init__` correctly raising `ValueError` on invalid input, etc.).
- Ruff caught a real issue on the first pass: the stub cells (bare `def foo(): ...`) were never called before being redefined in the solutions cell, which is genuinely flagged as `F811 redefined-while-unused` — unlike every existing stub→solution pair in these notebooks, which all call/use the stub within the same cell. Fixed by adding demo calls to each stub cell, matching that established convention. Re-ran ruff after the fix — clean.
- Re-validated all 8 touched notebooks as well-formed `nbformat` v4 JSON, and confirmed the "Created by..." footer cell is still the last cell in every file.
- `make lint`, `make check-out`, `make deps.check` all pass; diff only touches the intended 8 files, purely additive (no existing cells modified).